### PR TITLE
Corrected Resizer path for October CMS v3

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -2,7 +2,7 @@
 
 use System\Classes\PluginBase;
 use October\Rain\Database\Attach\File;
-use October\Rain\Database\Attach\Resizer;
+use October\Rain\Resize\Resizer;
 use PopcornPHP\ImageCompress\Models\Settings as ImageCompressSettings;
 
 class Plugin extends PluginBase


### PR DESCRIPTION
use October\Rain\Database\Attach\Resizer; is no longer valid and throws an error in October CMS V3.